### PR TITLE
package.json, bump react to ^0.13.1 from ^0.12.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   "author": "Nick Williams",
   "license": "MIT",
   "dependencies": {
-    "react": "^0.12.2"
+    "react": "^0.13.1"
   }
 }


### PR DESCRIPTION
react-clipboard uses react 0.13.1 in my project and throws no errors :ok: 
