### PR TITLE
Convert react-clipboard to full ES6 to remove React v15.5.0 deprecation warnings

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["react", "es2015"]
+  "presets": ["react", "es2015"],
+  "plugins": ["transform-class-properties"]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
 {
-  "presets": ["react", "es2015"],
-  "plugins": ["transform-class-properties"]
+  "presets": ["es2015", "stage-1", "react"]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015", "stage-1", "react"]
+  "presets": ["env", "react"],
+  "plugins": ["transform-class-properties"]
 }

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "devDependencies": {
     "babel-cli": "^6.23.0",
     "babel-core": "^6.23.1",
-    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-preset-es2015": "^6.22.0",
-    "babel-preset-react": "^6.23.0"
+    "babel-preset-react": "^6.23.0",
+    "babel-preset-stage-1": "^6.23.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,12 +26,14 @@
   "author": "Nick Williams",
   "license": "MIT",
   "peerDependencies": {
+    "prop-types": "^15.5.10",
     "react": "^0.14.0 || ^15.0.0",
     "react-dom": "^0.14.0 || ^15.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",
     "babel-core": "^6.23.1",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react": "^6.23.0"
   }

--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
   "author": "Nick Williams",
   "license": "MIT",
   "peerDependencies": {
-    "prop-types": "^15.5.0",
-    "react": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0"
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0-beta || ^16.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0-beta || ^16.0.0"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.0"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "devDependencies": {
     "babel-cli": "^6.23.0",
     "babel-core": "^6.23.1",
-    "babel-preset-es2015": "^6.22.0",
-    "babel-preset-react": "^6.23.0",
-    "babel-preset-stage-1": "^6.22.0"
+    "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-preset-env": "^1.6.0",
+    "babel-preset-react": "^6.23.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "babel-core": "^6.23.1",
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react": "^6.23.0",
-    "babel-preset-stage-1": "^6.23.0"
+    "babel-preset-stage-1": "^6.22.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "Nick Williams",
   "license": "MIT",
   "peerDependencies": {
-    "prop-types": "^15.5.10",
+    "prop-types": "^15.5.0",
     "react": "^0.14.0 || ^15.0.0",
     "react-dom": "^0.14.0 || ^15.0.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ class Clipboard extends React.Component {
     onCopy : PropTypes.func
   };
 
-  static defaultProps = defaultProps = {
+  static defaultProps = {
     className : "clipboard",
     style : {
       position : "fixed",

--- a/src/index.js
+++ b/src/index.js
@@ -1,53 +1,28 @@
 const React = require("react");
 const ReactDOM = require("react-dom");
+const PropTypes = require("prop-types");
 
-function noop() {}
-
-const Clipboard = React.createClass({
-
-  propTypes: {
-    value : React.PropTypes.string.isRequired,
-    className : React.PropTypes.string,
-    style : React.PropTypes.object,
-    onCopy : React.PropTypes.func
-  },
-
-  getDefaultProps() {
-    return {
-      className : "clipboard",
-      style : {
-        position : "fixed",
-        overflow : "hidden",
-        clip     : "rect(0 0 0 0)",
-        height   : 1,
-        width    : 1,
-        margin   : -1,
-        padding  : 0,
-        border   : 0
-      },
-      onCopy : noop
-    };
-  },
+class Clipboard extends React.Component {
 
   componentDidMount() {
     document.addEventListener("keydown", this.handleKeyDown, false);
     document.addEventListener("keyup", this.handleKeyUp, false);
-  },
+  }
 
   componentWillUnmount() {
     document.removeEventListener("keydown", this.handleKeyDown, false);
     document.removeEventListener("keyup", this.handleKeyUp, false);
-  },
+  }
 
   render() {
     return <textarea {...this.props} readOnly onCopy={this.handleCopy} />
-  },
+  }
 
-  handleCopy(e) {
+  handleCopy = e => {
     this.props.onCopy(e);
-  },
+  }
 
-  handleKeyDown(e) {
+  handleKeyDown = e => {
     const metaKeyIsDown = (e.ctrlKey || e.metaKey);
     const textIsSelected = window.getSelection().toString();
 
@@ -58,13 +33,35 @@ const Clipboard = React.createClass({
     const element = ReactDOM.findDOMNode(this);
     element.focus();
     element.select();
-  },
+  }
 
-  handleKeyUp(e) {
+  handleKeyUp = e => {
     const element = ReactDOM.findDOMNode(this);
     element.blur();
   }
 
-});
+};
+
+Clipboard.propTypes = {
+  value : PropTypes.string.isRequired,
+  className : PropTypes.string,
+  style : PropTypes.object,
+  onCopy : PropTypes.func
+};
+
+Clipboard.defaultProps = {
+  className : "clipboard",
+  style : {
+    position : "fixed",
+    overflow : "hidden",
+    clip     : "rect(0 0 0 0)",
+    height   : 1,
+    width    : 1,
+    margin   : -1,
+    padding  : 0,
+    border   : 0
+  },
+  onCopy : () => {} // noop
+};
 
 module.exports = Clipboard;

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,28 @@ const PropTypes = require("prop-types");
 
 class Clipboard extends React.Component {
 
+  static propTypes = {
+    value : PropTypes.string.isRequired,
+    className : PropTypes.string,
+    style : PropTypes.object,
+    onCopy : PropTypes.func
+  };
+
+  static defaultProps = defaultProps = {
+    className : "clipboard",
+    style : {
+      position : "fixed",
+      overflow : "hidden",
+      clip     : "rect(0 0 0 0)",
+      height   : 1,
+      width    : 1,
+      margin   : -1,
+      padding  : 0,
+      border   : 0
+    },
+    onCopy : () => {} // noop
+  };
+
   componentDidMount() {
     document.addEventListener("keydown", this.handleKeyDown, false);
     document.addEventListener("keyup", this.handleKeyUp, false);
@@ -40,28 +62,6 @@ class Clipboard extends React.Component {
     element.blur();
   }
 
-};
-
-Clipboard.propTypes = {
-  value : PropTypes.string.isRequired,
-  className : PropTypes.string,
-  style : PropTypes.object,
-  onCopy : PropTypes.func
-};
-
-Clipboard.defaultProps = {
-  className : "clipboard",
-  style : {
-    position : "fixed",
-    overflow : "hidden",
-    clip     : "rect(0 0 0 0)",
-    height   : 1,
-    width    : 1,
-    margin   : -1,
-    padding  : 0,
-    border   : 0
-  },
-  onCopy : () => {} // noop
 };
 
 module.exports = Clipboard;


### PR DESCRIPTION
This update removes deprecation warnings introduced in React v15.5.0
for React.PropTypes and React.createClass that were used in this
package.

(see: https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#new-deprecation-warnings)